### PR TITLE
add socks5 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pacproxy
 
 [![Build Status](https://travis-ci.org/williambailey/pacproxy.svg)](https://travis-ci.org/williambailey/pacproxy)
 
-A no-frills local HTTP proxy server powered by a [proxy auto-config (PAC) file](https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html). Especially handy when you are working in an environment with many different proxy servers and your applications don't support proxy auto-configuration.
+A no-frills local HTTP and SOCKS5 proxy server powered by a [proxy auto-config (PAC) file](https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html). Especially handy when you are working in an environment with many different proxy servers and your applications don't support proxy auto-configuration.
 
 ```
 $ ./pacproxy -h
@@ -12,6 +12,8 @@ Usage of ./bin/pacproxy:
     	PAC file name, url, or javascript to use
   -l string
     	Interface and port to listen on (default "127.0.0.1:8080")
+  -s string
+        Interface and port to listen on of socks5 proxy (default "127.0.0.1:1080")
   -v	send verbose output to STDERR
 ```
 

--- a/pacproxy.go
+++ b/pacproxy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/williambailey/pacproxy/pac"
+	"net"
 )
 
 // Name of the app
@@ -18,17 +19,49 @@ const Name = "pacproxy"
 const Version = "2.0.0"
 
 var (
-	fPac     string
-	fListen  string
-	fVerbose bool
+	fPac          string
+	fListen       string
+	fListenSocks5 string
+	fVerbose      bool
 )
 
 func init() {
 	flag.StringVar(&fPac, "c", "", "PAC file name, url or javascript to use")
-	flag.StringVar(&fListen, "l", "127.0.0.1:8080", "Interface and port to listen on")
+	flag.StringVar(&fListen, "l", "127.0.0.1:8080", "Interface and port to listen on of http proxy")
+	flag.StringVar(&fListenSocks5, "s", "127.0.0.1:1080", "Interface and port to listen on of socks5 proxy")
 	flag.BoolVar(&fVerbose, "v", false, "send verbose output to STDERR")
 }
-
+func serveHttpProxy(proxyFinder pac.ProxyFinder, proxySelector pac.ProxySelector) {
+	srv := &http.Server{
+		Addr:              fListen,
+		ReadHeaderTimeout: 2 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		Handler: newProxyHTTPHandler(
+			proxyFinder,
+			proxySelector,
+			newNonProxyHTTPHandler(),
+		),
+	}
+	log.Printf("Http Proxy listening on %q", fListen)
+	if err := srv.ListenAndServe(); err != nil {
+		log.Panic(err)
+	}
+}
+func serveSocks5Proxy(proxyFinder pac.ProxyFinder, proxySelector pac.ProxySelector) {
+	log.Printf("Socks5 Proxy listening on %q", fListen)
+	l, err := net.Listen("tcp", fListenSocks5)
+	if err != nil {
+		log.Panic(err)
+	}
+	handler := newProxySocksHandler(proxyFinder, proxySelector)
+	for {
+		client, err := l.Accept()
+		if err != nil {
+			log.Panic(err)
+		}
+		go handler.Handle(client)
+	}
+}
 func main() {
 	flag.Parse()
 	if fVerbose {
@@ -49,19 +82,15 @@ func main() {
 	defer otto.Stop()
 
 	initSignalNotify(otto)
-
-	srv := &http.Server{
-		Addr:              fListen,
-		ReadHeaderTimeout: 2 * time.Second,
-		IdleTimeout:       60 * time.Second,
-		Handler: newProxyHTTPHandler(
-			otto,
-			&pac.FirstItemSelector{},
-			newNonProxyHTTPHandler(),
-		),
-	}
-	log.Printf("Listening on %q", fListen)
-	if err := srv.ListenAndServe(); err != nil {
-		log.Panic(err)
-	}
+	finish := make(chan bool)
+	selector := &pac.FirstItemSelector{}
+	go func() {
+		serveHttpProxy(otto, selector)
+		finish <- true
+	}()
+	go func() {
+		serveSocks5Proxy(otto, selector)
+		finish <- true
+	}()
+	<-finish
 }

--- a/proxysockshandler.go
+++ b/proxysockshandler.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/url"
+	"time"
+
+	"bufio"
+	"github.com/williambailey/pacproxy/pac"
+	"net/http"
+	"strconv"
+)
+
+type proxySocks5Handler struct {
+	proxyFinder   pac.ProxyFinder
+	proxySelector pac.ProxySelector
+	dialer        *net.Dialer
+}
+
+func newProxySocksHandler(
+	proxyFinder pac.ProxyFinder,
+	proxySelector pac.ProxySelector,
+) *proxySocks5Handler {
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 10 * time.Second,
+	}
+	handler := &proxySocks5Handler{
+		proxyFinder,
+		proxySelector,
+		dialer,
+	}
+	return handler
+}
+
+func (h *proxySocks5Handler) lookupProxy(targetUrl *url.URL) (string, error) {
+	proxies, err := h.proxyFinder.FindProxyForURL(targetUrl)
+	if err != nil {
+		return "", err
+	}
+	proxy := h.proxySelector.SelectProxy(proxies)
+	log.Printf("Proxy Lookup %q, got %q. Selected %q", targetUrl, proxies, proxy)
+	if proxy == pac.DirectProxy {
+		return "", nil
+	}
+	host := fmt.Sprintf("%s:%d", proxy.Hostname, proxy.Port)
+	return host, nil
+}
+func (h *proxySocks5Handler) Handle(client net.Conn) {
+	if client == nil {
+		return
+	}
+	defer client.Close()
+
+	var b [1024]byte
+	n, err := client.Read(b[:])
+	if err != nil {
+		log.Printf("Socks5 Proxy read header failed: %s", err)
+		return
+	}
+
+	// only handle socks5 protocol
+	if b[0] != 0x05 {
+		return
+	}
+
+	// tell clients no need to auth
+	client.Write([]byte{0x05, 0x00})
+
+	//get target host port
+	n, err = client.Read(b[:])
+	var host, port string
+	switch b[3] {
+	case 0x01: // ipv4
+		host = net.IPv4(b[4], b[5], b[6], b[7]).String()
+	case 0x03: // domain
+		host = string(b[5 : n-2]) //b[4] length of domain
+	case 0x04: // ipv6
+		host = net.IP(b[4:19]).String()
+	}
+	port = strconv.Itoa(int(b[n-2])<<8 | int(b[n-1]))
+
+	backendAddr := net.JoinHostPort(host, port)
+	backendUrl, err := url.Parse("http://" + backendAddr)
+	if err != nil {
+		log.Printf("Socks5 Proxy parse url failed: %s", err)
+		return
+	}
+	// get proxy
+	proxyAddr, err := h.lookupProxy(backendUrl)
+	if err != nil {
+		log.Printf("Socks5 Proxy find proxy failed: %s", err)
+		return
+	}
+	// dial with CONNECT to http proxy
+	server, err := DialHttpProxy(proxyAddr, backendAddr, nil)
+	if err != nil {
+		log.Printf("Socks5 Proxy connect proxy failed: %s", err)
+		return
+	}
+	// tell client connection ready
+	client.Write([]byte{0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+
+	// pipe client and backend
+	go io.Copy(server, client)
+	io.Copy(client, server)
+}
+
+func DialHttpProxy(proxyAddr, backend string, auth *url.Userinfo) (net.Conn, error) {
+	// reference fellows:
+	// https://github.com/mwitkow/go-http-dialer
+	// https://github.com/golang/go/issues/17227
+	// https://gist.github.com/jim3ma/3750675f141669ac4702bc9deaf31c6b
+	// https://www.jianshu.com/p/172810a70fad
+	req := &http.Request{
+		Method: "CONNECT",
+		URL: &url.URL{
+			Host: backend,
+		},
+		Host:   backend,
+		Header: make(http.Header),
+		Close:  false,
+	}
+	if auth != nil {
+		password, _ := auth.Password()
+		req.SetBasicAuth(auth.Username(), password)
+	}
+	req.Header.Set("Proxy-Connection", "Keep-Alive")
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = req.Write(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		conn.Close()
+		return nil, fmt.Errorf("http proxy status=%d", resp.StatusCode)
+	}
+	return conn, nil
+}


### PR DESCRIPTION
I think socks5 server support will be quit useful, but I'm not sure if anyone would like two listening ports.
Let me known your idea, maybe I shoule not start it defaultly. If you don't like two  servers running default at startup, I can change the flag default value to empty, and check and skip the socks5 server.

It now works well, but response not fellow the socks5 protocol rfc docs. In fellow days I will add the correct response to socks5 clients according rfc.