### PR TITLE
Support for trailing semi-colon in multiple proxy string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.10.3
+
+WORKDIR /go/src/github.com/shakirshakiel/pacproxy
+COPY . .
+ENV CONFIG $CONFIG
+RUN make
+CMD /go/src/github.com/shakirshakiel/pacproxy/bin/pacproxy -c $CONFIG -v -l $HOSTNAME:8080

--- a/nonproxyhttphandler.go
+++ b/nonproxyhttphandler.go
@@ -15,7 +15,7 @@ func newNonProxyHTTPHandler() http.Handler {
 		}
 		http.Error(
 			w,
-			fmt.Sprintf("%s %s\nhttps://github.com/williambailey/pacproxy", Name, Version),
+			fmt.Sprintf("%s %s\nhttps://github.com/shakirshakiel/pacproxy", Name, Version),
 			http.StatusBadGateway,
 		)
 	})

--- a/pac/otto.go
+++ b/pac/otto.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/robertkrimen/otto"
-	"github.com/williambailey/pacproxy/pacfunc"
+	"github.com/shakirshakiel/pacproxy/pacfunc"
 )
 
 // OttoEngineOpt used to configure an OttoEngine via the NewOttoEngine func

--- a/pac/parse.go
+++ b/pac/parse.go
@@ -30,7 +30,7 @@ func ParseFindProxyString(s string) (Proxies, error) {
 		portInt  int
 		portErr  error
 	)
-	for _, statement := range pacStatementSplit.Split(s, 50) {
+	for _, statement := range FixedStatement(s) {
 		part := pacItemSplit.Split(statement, 2)
 		switch strings.ToUpper(part[0]) {
 		case "DIRECT":
@@ -61,4 +61,15 @@ func ParseFindProxyString(s string) (Proxies, error) {
 		}
 	}
 	return proxies, nil
+}
+
+func FixedStatement(s string) []string {
+	result := make([]string, 0)
+	statements := pacStatementSplit.Split(s, 50)
+	for _, statement := range statements {
+		if(statement != "") {
+			result = append(result, statement)
+		}
+	}
+	return result
 }

--- a/pac/parse_test.go
+++ b/pac/parse_test.go
@@ -14,6 +14,7 @@ var parsetests = []struct {
 	{"DIRECT", []Proxy{DirectProxy}, nil},
 	{"PROXY proxy.example.com:8080", []Proxy{Proxy{"proxy.example.com", 8080}}, nil},
 	{"PROXY proxy.example.com:8080; DIRECT", []Proxy{Proxy{"proxy.example.com", 8080}, DirectProxy}, nil},
+	{"PROXY proxy.example.com:8080; PROXY proxy.example.org:8888;", []Proxy{Proxy{"proxy.example.com", 8080}, Proxy{"proxy.example.org", 8888}}, nil},
 	{"PROXY proxy.example.com:8080; DIRECT; PROXY proxy.example.org:8888", []Proxy{Proxy{"proxy.example.com", 8080}, DirectProxy, Proxy{"proxy.example.org", 8888}}, nil},
 	{"FOO", []Proxy{}, errors.New("unsupported PAC command \"FOO\"")},
 	{"PROXY", []Proxy{}, errors.New("unable to parse proxy details from \"PROXY\"")},

--- a/pacproxy.go
+++ b/pacproxy.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/williambailey/pacproxy/pac"
+	"github.com/shakirshakiel/pacproxy/pac"
 )
 
 // Name of the app

--- a/pacproxy_no_signal.go
+++ b/pacproxy_no_signal.go
@@ -2,7 +2,7 @@
 
 package main
 
-import "github.com/williambailey/pacproxy/pac"
+import "github.com/shakirshakiel/pacproxy/pac"
 
 func initSignalNotify(_ pac.EngineManager) {
 }

--- a/pacproxy_signal.go
+++ b/pacproxy_signal.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/williambailey/pacproxy/pac"
+	"github.com/shakirshakiel/pacproxy/pac"
 )
 
 func initSignalNotify(pac pac.EngineManager) {

--- a/proxyhttphandler.go
+++ b/proxyhttphandler.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/williambailey/pacproxy/pac"
+	"github.com/shakirshakiel/pacproxy/pac"
 )
 
 type proxyHTTPHandler struct {


### PR DESCRIPTION
Hi @williambailey,

Many thanks for writing this library.

Sometimes the pac file can return proxy with a trailing semi-colon which can result in ""unsupported PAC command" error. 

In my scenario, PAC is configured to return something like "PROXY proxy.example.com:8080; PROXY proxy.example.org:8888;". In this case the regex identifies three records - "PROXY proxy.example.com:8080", "PROXY proxy.example.org:8888", "". The third record is empty and hence an unsupported PAC command. 

So I have written a method to filter out empty records. Please have a look.