### PR TITLE
Make `-c` a required argument

### DIFF
--- a/pacproxy.go
+++ b/pacproxy.go
@@ -16,7 +16,7 @@ import (
 const Name = "pacproxy"
 
 // Version of the app
-const Version = "2.0.1"
+const Version = "2.0.2"
 
 var (
 	fPac     string

--- a/pacproxy.go
+++ b/pacproxy.go
@@ -24,13 +24,24 @@ var (
 )
 
 func init() {
-	flag.StringVar(&fPac, "c", "", "PAC file name, url or javascript to use")
+	flag.StringVar(&fPac, "c", "", "PAC file name, url or javascript to use (required)")
 	flag.StringVar(&fListen, "l", "127.0.0.1:8080", "Interface and port to listen on")
 	flag.BoolVar(&fVerbose, "v", false, "send verbose output to STDERR")
 }
 
 func main() {
-	flag.Parse()
+	required := []string{"c"}
+      	flag.Parse()
+	
+	seen := make(map[string]bool)
+	flag.Visit(func(f *flag.Flag) { seen[f.Name] = true })
+        for _, req := range required {
+	    if !seen[req] {
+	        fmt.Fprintf(os.Stderr, "missing required -%s argument/flag\n", req)
+	        os.Exit(2) // the same exit code flag.Parse uses
+	    }
+        }
+	
 	if fVerbose {
 		log.SetOutput(os.Stderr)
 	} else {

--- a/pacproxy.go
+++ b/pacproxy.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"time"
+	"fmt"
 
 	"github.com/williambailey/pacproxy/pac"
 )


### PR DESCRIPTION
Currently `pacproxy` panics if invoked without supplying an argument via `-c`.

Change this so that we check whether the `-c` flag was used or not, and error out nicely instead of panicking.

(Perhaps we might even want to check if the string is empty as well?)