### PR TITLE
Return unclosed body to fix localhost redirects

### DIFF
--- a/proxyhttphandler.go
+++ b/proxyhttphandler.go
@@ -51,7 +51,8 @@ func newProxyHTTPHandler(
 		httpClient: &http.Client{
 			Transport: transport,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return errors.New("Don't follow redirects")
+				// Don't follow redirects, but do return their contents.
+				return http.ErrUseLastResponse
 			},
 			Jar: nil,
 		},


### PR DESCRIPTION
Use case scenario:
I'm testing a server locally that serves a 302 redirect. If I curl `localhost:<port>` through `pacproxy`, `curl` gives me a warning that the `Content-Length` header doesn't match the actual length of content in the response body.

Note: Redirects from remote servers seem to work fine. I think `curl` has special logic to slightly shortcut the proxy when you make a `localhost` request -- it sends an absolute URL rather than a `CONNECT` request.

From the documentation for `net/http.Client`:

> If CheckRedirect returns an error, the Client's Get method returns both the previous Response (with its Body closed) and CheckRedirect's error (wrapped in a url.Error) instead of issuing the Request req. As a special case, if CheckRedirect returns ErrUseLastResponse, then the most recent response is returned with its body unclosed, along with a nil error.

Since the response's `Body` is closed, no content is relayed, but the `Content-Length` header still makes it through, leading to the mismatch.

`ErrUseLastResponse` didn't exist when `pacproxy`'s `CheckRedirect` function was originally written. :)