### PR TITLE
Support for socks5 in pac file.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
+	github.com/txthinking/socks5 v0.0.0-20210716140126-fa1f52a8f2da
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,12 @@
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d h1:1VUlQbCfkoSGv7qP7Y+ro3ap1P1pPZxgdGVqiTVy5C4=
 github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
+github.com/txthinking/runnergroup v0.0.0-20210608031112-152c7c4432bf h1:7PflaKRtU4np/epFxRXlFhlzLXZzKFrH5/I4so5Ove0=
+github.com/txthinking/runnergroup v0.0.0-20210608031112-152c7c4432bf/go.mod h1:CLUSJbazqETbaR+i0YAhXBICV9TrKH93pziccMhmhpM=
+github.com/txthinking/socks5 v0.0.0-20210716140126-fa1f52a8f2da h1:7x8pJcBTdKTBpQbRjZZc9o6CDquXBbvm9UIrR6ZSRJ4=
+github.com/txthinking/socks5 v0.0.0-20210716140126-fa1f52a8f2da/go.mod h1:7NloQcrxaZYKURWph5HLxVDlIwMHJXCPkeWPtpftsIg=
+github.com/txthinking/x v0.0.0-20210326105829-476fab902fbe h1:gMWxZxBFRAXqoGkwkYlPX2zvyyKNWJpxOxCrjqJkm5A=
+github.com/txthinking/x v0.0.0-20210326105829-476fab902fbe/go.mod h1:WgqbSEmUYSjEV3B1qmee/PpP2NYEz4bL9/+mF1ma+s4=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=

--- a/pac/otto.go
+++ b/pac/otto.go
@@ -34,7 +34,6 @@ func NewOttoEngine(opts ...OttoEngineOpt) *OttoEngine {
 		loader: func() (string, error) {
 			return "", errors.New("pac loader has not been configured")
 		},
-		cache: make(map[string]Proxies),
 	}
 	for _, opt := range opts {
 		opt(otto)
@@ -72,6 +71,8 @@ func (o *OttoEngine) Start() error {
 	if o.isStarted {
 		return nil
 	}
+	// Init the cache when start, so the cache will be invalided when reload.
+	o.cache = make(map[string]Proxies)
 	log.Print("initialising OttoEngine")
 	vm := otto.New()
 
@@ -376,7 +377,7 @@ func (o *OttoEngine) FindProxyForURL(in *url.URL) (Proxies, error) {
 
 	r, err := ParseFindProxyString(findProxyString)
 	if err != nil {
-		return Proxies{}, nil
+		return Proxies{}, err
 	}
 	o.cache[in.Hostname()] = r
 	return r, nil

--- a/pac/pac.go
+++ b/pac/pac.go
@@ -54,8 +54,15 @@ type ProxyChecker interface {
 }
 */
 
+const (
+	ProxySchemeHttp   = "http"
+	ProxySchemeHttps  = "https"
+	ProxySchemeSocks5 = "socks5"
+)
+
 // Proxy information struct
 type Proxy struct {
+	Scheme   string
 	Hostname string
 	Port     int
 }
@@ -64,7 +71,7 @@ func (p Proxy) String() string {
 	if p == DirectProxy {
 		return "DIRECT"
 	}
-	return fmt.Sprintf("PROXY %s:%d", p.Hostname, p.Port)
+	return fmt.Sprintf("%s %s:%d", p.Scheme, p.Hostname, p.Port)
 }
 
 // DirectProxy is used to represent a "DIRECT" value


### PR DESCRIPTION
Thanks for make the tool. But it doesn't support a socks5 proxy in the pac file currently. I think a socks5 is very commonly for many users, such as the shadowsocks client export a socks5 server.
So I added this feature.

And I also added a cache in the OttoEngine, which make the `FindProxyForURL` faster.