### PR TITLE
Add option (-s) to explicitly specify the URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,21 @@ Usage:
         PAC file name, url or javascript to use (required)
   -l string
         Interface and port to listen on (default "127.0.0.1:8080")
+  -s string
+        Scheme to use for the URL passed to FindProxyForURL
   -v    send verbose output to STDERR
 ```
 
 ```bash
 # shell 1
-pacproxy -c 'function FindProxyForURL(url, host){ console.log("hello pac world!"); return "PROXY random.example.com:8080"; }'
+pacproxy -l 127.0.0.1:8080 -s http -c 'function FindProxyForURL(url, host){ console.log("hello pac world!"); return "PROXY random.example.com:8080"; }'
 # shell 2
+pacproxy -l 127.0.0.1:8443 -s https -c 'function FindProxyForURL(url, host){ console.log("hello pac world!"); return "PROXY random.example.com:8080"; }'
+# shell 3
 export http_proxy="127.0.0.1:8080"
-export https_proxy="127.0.0.1:8080"
+export https_proxy="127.0.0.1:8443"
 curl -I "http://www.example.com"
+curl -I "https://www.example.com"
 ```
 
 ## License

--- a/pacproxy.go
+++ b/pacproxy.go
@@ -28,12 +28,14 @@ const Repo = "https://github.com/williambailey/pacproxy"
 var (
 	fPac     string
 	fListen  string
+	fScheme  string
 	fVerbose bool
 )
 
 func init() {
 	flag.StringVar(&fPac, "c", "", "PAC file name, url or javascript to use (required)")
 	flag.StringVar(&fListen, "l", "127.0.0.1:8080", "Interface and port to listen on")
+	flag.StringVar(&fScheme, "s", "", "Scheme to use for the URL passed to FindProxyForURL")
 	flag.BoolVar(&fVerbose, "v", false, "send verbose output to STDERR")
 }
 

--- a/proxyhttphandler.go
+++ b/proxyhttphandler.go
@@ -76,12 +76,24 @@ func (h *proxyHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *proxyHTTPHandler) lookupProxy(r *http.Request) (*url.URL, error) {
-	proxies, err := h.proxyFinder.FindProxyForURL(r.URL)
+	sourceURL := &url.URL{
+		Scheme:      fScheme,
+		Opaque:      r.URL.Opaque,
+		User:        r.URL.User,
+		Host:        r.URL.Host,
+		Path:        r.URL.Path,
+		RawPath:     r.URL.RawPath,
+		ForceQuery:  r.URL.ForceQuery,
+		RawQuery:    r.URL.RawQuery,
+		Fragment:    r.URL.Fragment,
+		RawFragment: r.URL.RawFragment,
+	}
+	proxies, err := h.proxyFinder.FindProxyForURL(sourceURL)
 	if err != nil {
 		return nil, err
 	}
 	proxy := h.proxySelector.SelectProxy(proxies)
-	log.Printf("Proxy Lookup %q, got %q. Selected %q", r.URL, proxies, proxy)
+	log.Printf("Proxy Lookup %q, got %q. Selected %q", sourceURL, proxies, proxy)
 	if proxy == pac.DirectProxy {
 		return nil, nil
 	}


### PR DESCRIPTION
Explicitly specifying the URL scheme might be required depending on how the PAC file is written. For example, if the script returns a different value based on the URL scheme then passing the full URL to the `FindProxyForURL` method might be required.

Here's an example of such a (real life) PAC script:

```js
if ((url.substring(0,5) != "http:") && (url.substring(0,6) != "https:"))
return "DIRECT";
```

Since the [request URL scheme is not known][1], passing it explicitly through a command line option solves this issue.

The README has also been updated to reflect the intended usage of the new `-s` option.

Please bear in mind that this is the first time I ever write some go code. 😇

[1]: https://github.com/golang/go/issues/28940